### PR TITLE
Inject directory dir creation

### DIFF
--- a/lib/vm.rb
+++ b/lib/vm.rb
@@ -178,7 +178,7 @@ class VM
         "-o",
         "StrictHostKeyChecking=no",
         "root@#{@ip}",
-        "chown -R #{owner_group} #{destination}/#{File.basename(source)}"
+        "chown -R #{owner_group} '#{destination}'"
       )
     end
   rescue Cheetah::ExecutionFailed => e

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -104,6 +104,16 @@ describe VM do
       system.ip = "1.2.3.4"
       system.inject_directory("/tmp/hosts", "/etc")
     end
+
+    it "copies the directory and sets the user and group" do
+      expect(Cheetah).to receive(:run) { |*args| expect(args).to include(/mkdir -p/) }
+      expect(Cheetah).to receive(:run) { |*args| expect(args).to include(/scp/) }
+      expect(Cheetah).to receive(:run) { |*args| expect(args).to include(/chown -R user:group/) }
+
+      system = VM.new(nil)
+      system.ip = "1.2.3.4"
+      system.inject_directory("/tmp/hosts", "/etc", owner: "user", group: "group")
+    end
   end
 
 end


### PR DESCRIPTION
Similar to Vagrant's synced_folder the destination directory is created recursively if it doesn't exist.

The provided user:group parameters are also applied.
