### PR TITLE
Run su commands with login shell

### DIFF
--- a/lib/vm.rb
+++ b/lib/vm.rb
@@ -50,7 +50,7 @@ class VM
     escaped_args = args.map { |a| Shellwords.escape(a) }
 
     if user = options.delete(:as)
-      escaped_args = ["su", user, "-c"] + escaped_args
+      escaped_args = ["su", "-l", user, "-c"] + escaped_args
     end
 
     Cheetah.run(

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -36,7 +36,7 @@ describe VM do
       expect(Cheetah).to receive(:run).
         with(
           "ssh", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no",
-          "root@1.2.3.4", "LC_ALL=C", "su", "vagrant", "-c", "ls", "-l", "/etc/hosts",
+          "root@1.2.3.4", "LC_ALL=C", "su", "-l", "vagrant", "-c", "ls", "-l", "/etc/hosts",
           {:stdout=>:capture}).
         and_return(ssh_output)
 


### PR DESCRIPTION
We had an issue with our integration test that ruby wanted to change to
/root which it couldn't access.
The reason for this was a FileUtils.cd block, which tried to change back
to root, because the environment variables were the same as for root.
Running su with the "-l" parameter fixes this issue.
