### PR TITLE
[Review] Request from 'greygoo' @ 'SUSE/pennyworth/review_141028_make_ssh_key_deployment_configurable_'

### DIFF
--- a/lib/spec.rb
+++ b/lib/spec.rb
@@ -31,6 +31,9 @@ require_relative "spec_profiler"
 module Pennyworth
   module SpecHelper
     def start_system(opts)
+      opts = {
+        skip_ssh_setup: false
+      }.merge(opts)
       if opts[:box]
         runner = VagrantRunner.new(opts[:box], RSpec.configuration.vagrant_dir)
         password = "vagrant"
@@ -51,7 +54,9 @@ module Pennyworth
       measure("Boot machine '#{opts[:box] || opts[:image]}'") do
         system.start
       end
-      SshKeysImporter.import(system.ip, password)
+      if !opts[:skip_ssh_setup]
+        SshKeysImporter.import(system.ip, password)
+      end
 
       system
     end


### PR DESCRIPTION
Please review the following changes:
- 820c483 Make ssh key setup optional for cases of test booting an image that already has an ssh key deployed.
- e9fa775 Update README.md
- 7cfaf92 Merge pull request #18 from SUSE/review_141015_enable_hound
- a05c42a Enable Hound checking for our pull requests
