### PR TITLE
Remote hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,17 @@ in the pennyworth command line application. Get an overview by running
 
 To initially set up the test infrastructure run
 
-    pennyworth host setup http://ci.example.org
+    pennyworth host setup http://ci.example.org/pennyworth/hosts.yaml
 
-This will copy the `hosts.yaml` configuration file from
-`http://ci.example.com/pennyworth/hosts.yaml` to your local configuration so
-that it is picked up by Pennyworth automatically. This makes it easy to
-distribute a common configuration between several systems and users.
+with a URL corresponding to where you store the configuration of your test
+hosts. This will create a configuration file which includes the configuration
+from `http://ci.example.com/pennyworth/hosts.yaml` as a reference. The
+configuration will dynamically be fetched from the URL when tests are run.
+You can add local configuration to the `~/.pennyworth/hosts.yaml` file. If it
+defines values for keys from the remote file it overwrites the value by the
+local attribute. This setup makes it easy to distribute a common configuration
+between several systems and users, while still allowing users to have their
+local settings.
 
 Pennyworth automatically cleans up the hosts after running the tests using
 snapper snapshots. The snapshot which the system is rolled back to is specified

--- a/lib/cli_host_controller.rb
+++ b/lib/cli_host_controller.rb
@@ -28,7 +28,7 @@ class CliHostController
 
     @out.puts "Setup from '#{url}'"
     begin
-      HostConfig.for_directory(@config_dir).fetch(url)
+      HostConfig.for_directory(@config_dir).setup(url)
     rescue HostFileError => e
       @out.puts "Error: #{e}"
     end

--- a/lib/host_config.rb
+++ b/lib/host_config.rb
@@ -26,14 +26,39 @@ class HostConfig
     @config_file = File.expand_path(config_file)
   end
 
-  def read
-    yaml = YAML.load_file(config_file)
-    if yaml && yaml["hosts"]
-      @hosts = yaml["hosts"]
-      @lock_server_address = yaml["lock_server_address"]
-    else
+  def parse(yaml_string)
+    yaml = YAML.load(yaml_string)
+    if !yaml
       raise HostFileError.new("Could not parse YAML in file '#{config_file}'")
     end
+
+    if yaml["include"]
+      begin
+        open(yaml["include"], "rb") do |u|
+          parse(u.read)
+        end
+      rescue OpenURI::HTTPError, Errno::ENOENT
+        raise HostFileError.new("Unable to include '#{yaml["include"]}'")
+      end
+    end
+
+    if yaml["hosts"]
+      if !@hosts
+        @hosts = yaml["hosts"]
+      else
+        yaml["hosts"].each do |key, value|
+          @hosts[key] = value
+        end
+      end
+    end
+
+    if yaml["lock_server_address"]
+      @lock_server_address = yaml["lock_server_address"]
+    end
+  end
+
+  def read
+    parse(File.read(config_file))
   end
 
   def hosts

--- a/lib/host_config.rb
+++ b/lib/host_config.rb
@@ -69,20 +69,16 @@ class HostConfig
     @hosts[host_name]
   end
 
-  def fetch(url)
-    file_url = url + "/pennyworth/hosts.yaml"
-    body = nil
-    begin
-      open(file_url, "rb") do |u|
-        body = u.read
-      end
-    rescue OpenURI::HTTPError
-      raise HostFileError.new("Unable to fetch from '#{file_url}'")
+  def setup(url)
+    if File.exist?(config_file)
+      raise HostFileError.new("Config file '#{config_file}' already exists." +
+        " Canceling setup.")
     end
 
     FileUtils.mkdir_p(File.dirname(config_file))
     File.open(config_file, "w") do |f|
-      f.write(body)
+      f.puts("---")
+      f.puts("include: #{url}")
     end
   end
 end

--- a/spec/host_config_spec.rb
+++ b/spec/host_config_spec.rb
@@ -115,11 +115,12 @@ hosts:
     address: a.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {
-          "Accept" => "*/*",
-          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "User-Agent" => "Ruby"
-        }).
+        with(headers:
+          {
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "User-Agent" => "Ruby"
+          }).
         to_return(status: 200, body: body, headers: {})
 
       file = <<EOT
@@ -141,11 +142,12 @@ hosts:
     address: a.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {
-          "Accept" => "*/*",
-          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "User-Agent" => "Ruby"
-        }).
+        with(headers:
+          {
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "User-Agent" => "Ruby"
+          }).
         to_return(status: 200, body: body, headers: {})
 
       file = <<EOT
@@ -170,11 +172,12 @@ hosts:
     address: c.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {
-          "Accept" => "*/*",
-          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "User-Agent" => "Ruby"
-        }).
+        with(headers:
+          {
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "User-Agent" => "Ruby"
+          }).
         to_return(status: 200, body: body, headers: {})
 
       file = <<EOT

--- a/spec/host_config_spec.rb
+++ b/spec/host_config_spec.rb
@@ -115,8 +115,12 @@ hosts:
     address: a.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-        to_return(:status => 200, :body => body, :headers => {})
+        with(:headers => {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Ruby"
+        }).
+        to_return(status: 200, body: body, headers: {})
 
       file = <<EOT
 ---
@@ -137,8 +141,12 @@ hosts:
     address: a.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-        to_return(:status => 200, :body => body, :headers => {})
+        with(:headers => {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Ruby"
+        }).
+        to_return(status: 200, body: body, headers: {})
 
       file = <<EOT
 ---
@@ -162,8 +170,12 @@ hosts:
     address: c.example.com
 EOT
       stub_request(:get, "http://ci.example.com/pennyworth/hosts.yaml").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-        to_return(:status => 200, :body => body, :headers => {})
+        with(:headers => {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Ruby"
+        }).
+        to_return(status: 200, body: body, headers: {})
 
       file = <<EOT
 ---


### PR DESCRIPTION
This pull requests implements dynamic inclusion of the remote configuration, so that the shared remote `hosts.yaml` file doesn't have to be manually updated locally anymore, when it changes on the server.