### PR TITLE
Make sure to cleanup hosts when the tests are interrupted

### DIFF
--- a/lib/host_runner.rb
+++ b/lib/host_runner.rb
@@ -113,10 +113,10 @@ class HostRunner
         exit!(1)
       end
 
-      Machinery::Ui.puts "RSpec is shutting down. Resetting test host '#{@ip}'." \
+      puts "RSpec is shutting down. Resetting test host '#{@ip}'." \
         "Interrupt again to force exit."
       cleanup
-      Machinery::Ui.puts "Done."
+      puts "Done."
 
       @old_interrupt_handler.call
     end

--- a/lib/host_runner.rb
+++ b/lib/host_runner.rb
@@ -33,7 +33,7 @@ class HostRunner
         "Missing 'address' field for host '#{host_name}' in '#{config_file}'"
       )
     end
-    if !@base_snapshot_id && !ENV["SKIP_CLEANUP"]
+    if should_cleanup && !@base_snapshot_id
       raise InvalidHostError.new(
         "Missing 'base_snapshot_id' field for host '#{host_name}' in '#{config_file}'"
       )
@@ -48,23 +48,32 @@ class HostRunner
     end
 
     connect
-    check_cleanup_capabilities if !ENV["SKIP_CLEANUP"]
+
+    if should_cleanup
+      check_cleanup_capabilities
+      install_cleanup_interrupt_handler
+    end
 
     @ip
   end
 
   def cleanup
+    return if @cleaned_up || !@connected
+
     remote = RemoteCommandRunner.new(@ip)
     remote.run "snapper", "create", "-c", "number", "--pre-number", @base_snapshot_id.to_s,
       "--description", "pennyworth_snapshot"
     remote.run "snapper", "undochange", "#{@base_snapshot_id}..0"
     remote.run "bash", "-c", "reboot &"
+    @cleaned_up = true
   end
 
   def stop
-    if @connected && !ENV["SKIP_CLEANUP"]
+    if should_cleanup
       cleanup
+      uninstall_cleanup_interrupt_handler
     end
+
     @locker.release_lock(@host_name)
   end
 
@@ -92,5 +101,29 @@ class HostRunner
       )
     end
     @connected = true
+  end
+
+  def should_cleanup
+    !ENV["SKIP_CLEANUP"]
+  end
+
+  def install_cleanup_interrupt_handler
+    @old_interrupt_handler = trap("INT") do
+      trap("INT") do
+        exit!(1)
+      end
+
+      Machinery::Ui.puts "RSpec is shutting down. Resetting test host '#{@ip}'." \
+        "Interrupt again to force exit."
+      cleanup
+      Machinery::Ui.puts "Done."
+
+      @old_interrupt_handler.call
+    end
+  end
+
+  def uninstall_cleanup_interrupt_handler
+    # Restore old interrupt handler
+    trap("INT", @old_interrupt_handler) if defined?(@old_interrupt_handler)
   end
 end

--- a/spec/host_runner_spec.rb
+++ b/spec/host_runner_spec.rb
@@ -68,13 +68,6 @@ describe HostRunner do
       runner.stop
     end
 
-    it "does not trigger a cleanup when the host was not connected" do
-      runner.instance_variable_set(:@connected, false)
-      expect(runner).to_not receive(:cleanup)
-
-      runner.stop
-    end
-
     it "does not trigger a cleanup when SKIP_CLEANUP is set" do
       runner.instance_variable_set(:@connected, true)
       expect(runner).to_not receive(:cleanup)
@@ -82,6 +75,33 @@ describe HostRunner do
       with_env "SKIP_CLEANUP" => "true" do
         runner.stop
       end
+    end
+  end
+
+  describe "#cleanup" do
+    it "cleans up the host" do
+      runner.instance_variable_set(:@connected, true)
+      runner.instance_variable_set(:@cleaned_up, false)
+      command_runner = double(:run)
+      expect(command_runner).to receive(:run).at_least(:once)
+      expect(RemoteCommandRunner).to receive(:new).and_return(command_runner)
+
+      runner.cleanup
+    end
+    it "does not clean up when the host was not connected" do
+      runner.instance_variable_set(:@connected, false)
+      runner.instance_variable_set(:@cleaned_up, false)
+      expect(RemoteCommandRunner).to_not receive(:new)
+
+      runner.cleanup
+    end
+
+    it "does not clean up when the host was already cleaned up" do
+      runner.instance_variable_set(:@connected, true)
+      runner.instance_variable_set(:@cleaned_up, true)
+      expect(RemoteCommandRunner).to_not receive(:new)
+
+      runner.cleanup
     end
   end
 end


### PR DESCRIPTION
When the tests were interrupted by the user the system was previously
left in a dirty state, causing problems for the next test run. That is
now prevented by installing a signal handler which triggers the cleanup.
