### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/pennyworth/review_150115_pennyworth_host_reset'

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -280,6 +280,14 @@ class Cli
       end
     end
 
+    c.desc "reset host to defined state"
+    c.arg :host_name
+    c.command :reset do |sc|
+      sc.action do |_, _, args|
+        Cli.host_controller.reset(args[0])
+      end
+    end
+
     c.desc "show information about host"
     c.arg :host_name
     c.command :info do |sc|

--- a/lib/cli_host_controller.rb
+++ b/lib/cli_host_controller.rb
@@ -35,8 +35,6 @@ class CliHostController
   end
 
   def list
-    host_config = HostConfig.for_directory(@config_dir)
-    host_config.read
     host_config.hosts.each do |host_name|
       host = host_config.host(host_name)
       out = "#{host_name}"
@@ -59,8 +57,6 @@ class CliHostController
       raise GLI::BadCommandLine.new("Please provide a host name argument")
     end
 
-    host_config = HostConfig.for_directory(@config_dir)
-    host_config.read
     if !host_config.host(host_name)
       raise LockError.new("Host name #{host_name} doesn't exist in " +
         "configuration file '#{host_config.config_file}'")
@@ -82,8 +78,6 @@ class CliHostController
       raise GLI::BadCommandLine.new("Please provide a host name argument")
     end
 
-    host_config = HostConfig.for_directory(@config_dir)
-    host_config.read
     if !host_config.host(host_name)
       raise LockError.new("Host name #{host_name} doesn't exist in " +
         "configuration file '#{host_config.config_file}'")
@@ -91,5 +85,16 @@ class CliHostController
 
     locker = LockService.new(host_config.lock_server_address)
     @out.puts(locker.info(host_name))
+  end
+
+  private
+
+  def host_config
+    return @host_config if @host_config
+
+    @host_config = HostConfig.for_directory(@config_dir)
+    @host_config.read
+
+    @host_config
   end
 end

--- a/lib/cli_host_controller.rb
+++ b/lib/cli_host_controller.rb
@@ -53,14 +53,7 @@ class CliHostController
   end
 
   def lock(host_name)
-    if !host_name
-      raise GLI::BadCommandLine.new("Please provide a host name argument")
-    end
-
-    if !host_config.host(host_name)
-      raise LockError.new("Host name #{host_name} doesn't exist in " +
-        "configuration file '#{host_config.config_file}'")
-    end
+    check_host(host_name)
 
     locker = LockService.new(host_config.lock_server_address)
     if locker.request_lock(host_name)
@@ -74,6 +67,15 @@ class CliHostController
   end
 
   def info(host_name)
+    check_host(host_name)
+
+    locker = LockService.new(host_config.lock_server_address)
+    @out.puts(locker.info(host_name))
+  end
+
+  private
+
+  def check_host(host_name)
     if !host_name
       raise GLI::BadCommandLine.new("Please provide a host name argument")
     end
@@ -82,12 +84,7 @@ class CliHostController
       raise LockError.new("Host name #{host_name} doesn't exist in " +
         "configuration file '#{host_config.config_file}'")
     end
-
-    locker = LockService.new(host_config.lock_server_address)
-    @out.puts(locker.info(host_name))
   end
-
-  private
 
   def host_config
     return @host_config if @host_config

--- a/lib/cli_host_controller.rb
+++ b/lib/cli_host_controller.rb
@@ -73,6 +73,14 @@ class CliHostController
     @out.puts(locker.info(host_name))
   end
 
+  def reset(host_name)
+    check_host(host_name)
+
+    runner = HostRunner.new(host_name, host_config)
+    runner.start
+    runner.cleanup
+  end
+
   private
 
   def check_host(host_name)

--- a/lib/host_runner.rb
+++ b/lib/host_runner.rb
@@ -16,11 +16,10 @@
 # you may find current contact information at www.suse.com
 
 class HostRunner
-  def initialize(host_name, config_file)
+  def initialize(host_name, host_config)
     @host_name = host_name
+    config_file = host_config.config_file
 
-    host_config = HostConfig.new(config_file)
-    host_config.read
     host = host_config.host(host_name)
     if !host
       raise InvalidHostError.new("Host '#{host_name}' is not defined in '#{config_file}'")

--- a/lib/spec.rb
+++ b/lib/spec.rb
@@ -18,6 +18,7 @@
 require "cheetah"
 require "libvirt"
 require "socket"
+require "open-uri"
 
 require_relative "exceptions"
 require_relative "helper"
@@ -46,7 +47,9 @@ module Pennyworth
         runner = ImageRunner.new(opts[:image])
         password = "linux"
       elsif opts[:host]
-        runner = HostRunner.new(opts[:host], RSpec.configuration.hosts_file)
+        config = HostConfig.new(RSpec.configuration.hosts_file)
+        config.read
+        runner = HostRunner.new(opts[:host], config)
       end
 
       raise "No image specified." unless runner

--- a/spec/host_runner_spec.rb
+++ b/spec/host_runner_spec.rb
@@ -18,8 +18,13 @@
 require "spec_helper"
 
 describe HostRunner do
+  let(:host_config) {
+    config = HostConfig.for_directory(test_data_dir)
+    config.read
+    config
+  }
   let(:runner) {
-    HostRunner.new("test_host", File.join(test_data_dir, "hosts.yaml"))
+    HostRunner.new("test_host", host_config)
   }
 
   it_behaves_like "a runner"
@@ -27,19 +32,19 @@ describe HostRunner do
   describe "#initialize" do
     it "fails with error, if host is not known" do
       expect {
-        HostRunner.new("invalid_name", File.join(test_data_dir, "hosts.yaml"))
+        HostRunner.new("invalid_name", host_config)
       }.to raise_error(InvalidHostError)
     end
 
     it "fails with error, if address is not set" do
       expect {
-        HostRunner.new("missing_address", File.join(test_data_dir, "hosts.yaml"))
+        HostRunner.new("missing_address", host_config)
       }.to raise_error(InvalidHostError)
     end
 
     it "fails with error, if base_snapshot_id is not set" do
       expect {
-        HostRunner.new("missing_snapshot_id", File.join(test_data_dir, "hosts.yaml"))
+        HostRunner.new("missing_snapshot_id", host_config)
       }.to raise_error(InvalidHostError)
     end
   end

--- a/spec/spec_spec.rb
+++ b/spec/spec_spec.rb
@@ -79,7 +79,7 @@ describe Pennyworth::SpecHelper do
       runner = double
       expect(runner).to receive(:start)
       expect(HostRunner).to receive(:new).
-        with("test_host", RSpec.configuration.hosts_file).
+        with("test_host", instance_of(HostConfig)).
         and_return(runner)
       expect(SshKeysImporter).to_not receive(:import)
 


### PR DESCRIPTION
Please review the following changes:
  * fe6989b Implement "pennyworth host reset" to reset a host to the defined state
  * 2ac92f5 Initialize HostRunner with a HostConfig instead of a path to the config
  * 96edf25 DRY up host name parameter check
  * 7eab042 DRY up access to the host configuration