### PR TITLE
Add snapper cleanup part to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,16 @@ In order to use a system as a pennyworth host it needs to be prepared like this:
   1. The root partition needs to be a Btrfs partition
   2. Snapper needs to be installed and configured for `/`:
 
+        Enable snapper for root by running:
         snapper create-config /
+
+        Disable the timeline for the new config:
+        snapper -c root set-config "TIMELINE_CREATE=no"
+
+        Disable the automatic zypper snapshots by removing the plugin:
+        zypper rm snapper-zypp-plugin
+
+        (Ref.: https://www.suse.com/documentation/sles-12/singlehtml/book_sle_admin/book_sle_admin.html#sec.snapper.setup.customize.auto_snapshots )
 
   3. There can't be any subvolumes below `/` besides `.snapshots`
   4. It's usually helpful to exclude `*/.ssh` from the rollback so that SSH


### PR DESCRIPTION
Add howto for preventing disk space issues by disabling automatic
snapper snapshots for the timeline (backups) or during zypper usage.