### PR TITLE
Make SKIP_CLEANUP explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ snapshot named `pennyworth` is created which can be used for debugging test
 failures.
 
 In some cases (e.g. while working on a test) the automatic rollback might not be
-desired. It can easily be disabled temporarily by setting the `SKIP_CLEANUP`
-environment variable, e.g.
+desired. It can easily be disabled temporarily by setting the
+`SKIP_HOST_CLEANUP` environment variable, e.g.
 
-    SKIP_CLEANUP=true rspec
+    SKIP_HOST_CLEANUP=true rspec
 
 An example for the configuration file is:
 

--- a/lib/host_runner.rb
+++ b/lib/host_runner.rb
@@ -104,7 +104,7 @@ class HostRunner
   end
 
   def should_cleanup
-    !ENV["SKIP_CLEANUP"]
+    !ENV["SKIP_HOST_CLEANUP"]
   end
 
   def install_cleanup_interrupt_handler

--- a/spec/host_runner_spec.rb
+++ b/spec/host_runner_spec.rb
@@ -73,11 +73,11 @@ describe HostRunner do
       runner.stop
     end
 
-    it "does not trigger a cleanup when SKIP_CLEANUP is set" do
+    it "does not trigger a cleanup when SKIP_HOST_CLEANUP is set" do
       runner.instance_variable_set(:@connected, true)
       expect(runner).to_not receive(:cleanup)
 
-      with_env "SKIP_CLEANUP" => "true" do
+      with_env "SKIP_HOST_CLEANUP" => "true" do
         runner.stop
       end
     end


### PR DESCRIPTION
The name of SKIP_CLEANUP environment variable conflicted with one of our
rake rpm build scripts. So I made the name explicit.