### PR TITLE
Limit rspec version to 3.1.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.1.0'
   gem 'webmock'
 end


### PR DESCRIPTION
Rspec 3.2.0 has changed the hook handling witch breaks the
pennyworth tests.

spec/spec_spec.rb line 40, 59, 78