### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/pennyworth/review_150619_introduce_new_syntax_and_matchers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,41 @@ with the running machine (via SSH). It supports the following methods:
     Stops or disconnects the system. This stops running boxes or images and disconnects from
     running systems.
 
-  * `run_command(command, *args, options = {})`
-    `run_command(command_and_args, options = {})`
+  * `run(command, *args, options = {})`
+    `run(command_and_args, options = {})`
 
-    Executes a command on the running machine. The execution is implemented
-    using [Cheetah](https://github.com/opensuse/cheetah) and the `run_command`
-    method behaves mostly the same as
-    [`Cheetah.run`](http://rubydoc.info/github/openSUSE/cheetah/master/Cheetah.run).
+    Executes a command on the running machine. A VM::CommandResult instance is
+    returned which can be used with special RSpec matchers to define the
+    expected behavior. Examples:
+
+      # Expect a certain exit code
+      expect(@vm.run("ls -l")).to have_exit_code(0)
+
+      # Expect exit code 0 and no stderr
+      expect(result).to succeed
+
+      # Expect a certain stdout
+      expect(result).to succeed.and have_stdout(/foo.*bar/)
+      expect(result).to succeed.and have_stdout("foo bar")
+
+      # Expect exit code 0, but some stderr output
+      expect(result).to succeed.with_stderr
+
+      # Expect the stdout to include a certain string
+      expect(result).to include_stdout("foo bar")
+
+      # Expect exit code != 0
+      expect(result).to fail
+
+      # Expect a specific exit code
+      expect(result).to fail.with_exit_code(15)
+
+      # Expect specific stderr
+      expect(result).to have_stderr(/This.*error/)
+      expect(result).to have_stderr("This is an error")
+
+      # Expect stderr to include a certain string
+      expect(result).to include_stderr("Warning"
 
   * `inject_file(source, destination)`
 

--- a/README.md
+++ b/README.md
@@ -297,18 +297,18 @@ with the running machine (via SSH). It supports the following methods:
     Stops or disconnects the system. This stops running boxes or images and disconnects from
     running systems.
 
-  * `run(command, *args, options = {})`
-    `run(command_and_args, options = {})`
+  * `run_command(command, *args, options = {})`
+    `run_command(command_and_args, options = {})`
 
     Executes a command on the running machine. A VM::CommandResult instance is
     returned which can be used with special RSpec matchers to define the
     expected behavior. Examples:
 
-      # Expect a certain exit code
-      expect(@vm.run("ls -l")).to have_exit_code(0)
-
       # Expect exit code 0 and no stderr
       expect(result).to succeed
+
+      # Expect exit code 0, ignoring any stderr
+      expect(@vm.run_command("ls -l")).to succeed.with_or_without_stderr
 
       # Expect a certain stdout
       expect(result).to succeed.and have_stdout(/foo.*bar/)

--- a/lib/pennyworth/exceptions.rb
+++ b/lib/pennyworth/exceptions.rb
@@ -24,16 +24,4 @@ module Pennyworth
   class InvalidHostError < StandardError; end
   class HostFileError < StandardError; end
   class LockError < StandardError; end
-
-  class ExecutionFailed < StandardError
-    def initialize(e)
-      @message = e.message
-      @message += "\nStandard output:\n #{e.stdout}\n"
-      @message += "\nError output:\n #{e.stderr}\n"
-    end
-
-    def to_s
-      @message
-    end
-  end
 end

--- a/lib/pennyworth/local_command_runner.rb
+++ b/lib/pennyworth/local_command_runner.rb
@@ -39,8 +39,6 @@ module Pennyworth
           "bash", "-c", *args, options
         )
       end
-    rescue Cheetah::ExecutionFailed => e
-      raise ExecutionFailed.new(e)
     end
 
     # Copy a local file to the remote system.

--- a/lib/pennyworth/matchers.rb
+++ b/lib/pennyworth/matchers.rb
@@ -1,0 +1,150 @@
+# Copyright (c) 2013-2014 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+RSpec::Matchers.define :have_exit_code do |expected|
+  match do |result|
+    result.exit_code == expected
+  end
+end
+
+RSpec::Matchers.define :fail do
+  match do |result|
+    if @exit_code
+      result.exit_code == @exit_code
+    else
+      result.exit_code != 0
+    end
+  end
+
+  chain :with_exit_code do |exit_code|
+    @exit_code = exit_code
+  end
+
+  failure_message do |result|
+    message = "Expected\n    #{result.cmd}\nto fail"
+    if @exit_code
+      message += " with exit code #{@exit_code} but it exited with #{result.exit_code}"
+    else
+      message += " but it succeeded."
+    end
+
+    message
+  end
+end
+
+RSpec::Matchers.define :have_stderr do |expected|
+  match do |result|
+    if expected.is_a?(Regexp)
+      expected.match(result.stderr)
+    else
+      expected == result.stderr
+    end
+  end
+
+  failure_message do |result|
+    if expected.is_a?(Regexp)
+      message = "Expected stderr to match #{expected.inspect}"
+      message += " (was:\n\n#{(result.stderr)})"
+    else
+      message = "Expected stderr to be '#{expected}'"
+      message += "\n\nDiff of stderr:"
+      differ = RSpec::Support::Differ.new(color: true)
+      message += differ.diff(result.stderr, expected)
+    end
+
+    message
+  end
+end
+
+RSpec::Matchers.define :include_stderr do |expected|
+  match do |result|
+    result.stderr.include? expected
+  end
+
+  failure_message do |result|
+    "Expected stderr '#{result.stdout}' to include '#{expected}'"
+  end
+  failure_message_when_negated do |result|
+    "Expected stderr '#{result.stdout}' to not include '#{expected}'"
+  end
+end
+RSpec::Matchers.define_negated_matcher :not_include_stderr, :include_stderr
+
+RSpec::Matchers.define :have_stdout do |expected|
+  match do |result|
+    if expected.is_a?(Regexp)
+      expected.match(result.stdout)
+    else
+      expected == result.stdout
+    end
+  end
+
+  failure_message do |result|
+    if expected.is_a?(Regexp)
+      message = "Expected stdout to match #{expected.inspect}"
+      message += " (was:\n\n#{(result.stdout)})"
+    else
+      message = "Expected stdout to be '#{expected}'"
+      message += "\n\nDiff of stdout:"
+      differ = RSpec::Support::Differ.new(color: true)
+      message += differ.diff(result.stdout, expected)
+    end
+
+    message
+  end
+end
+
+RSpec::Matchers.define :include_stdout do |expected|
+  match do |result|
+    result.stdout.include? expected
+  end
+
+  failure_message do |result|
+    "Expected stdout '#{result.stdout}' to include '#{expected}'"
+  end
+  failure_message_when_negated do |result|
+    "Expected stdout '#{result.stdout}' to not include '#{expected}'"
+  end
+end
+RSpec::Matchers.define_negated_matcher :not_include_stdout, :include_stdout
+
+RSpec::Matchers.define :succeed do
+  chain :with_stderr do
+    @allow_stderr = true
+  end
+
+  match do |result|
+    return false if result.exit_code != 0
+    return false if !result.stderr.empty? && !@allow_stderr
+    return false if result.stderr.empty? && @allow_stderr
+
+    true
+  end
+
+  failure_message do |result|
+    message = "Expected\n    #{result.cmd}\nto succeed"
+    if result.exit_code != 0
+      message += " but it returned with exit code #{result.exit_code}"
+    elsif !result.stderr.empty? && !@allow_stderr
+      message += " but it had stderr output.\nThe output was:\n#{result.stderr}"
+    elsif result.stderr.empty? && @allow_stderr
+      message += " with stderr output but stderr was empty."
+    end
+
+    message
+  end
+end

--- a/lib/pennyworth/matchers.rb
+++ b/lib/pennyworth/matchers.rb
@@ -15,12 +15,6 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-RSpec::Matchers.define :have_exit_code do |expected|
-  match do |result|
-    result.exit_code == expected
-  end
-end
-
 RSpec::Matchers.define :fail do
   match do |result|
     if @exit_code
@@ -127,9 +121,13 @@ RSpec::Matchers.define :succeed do
     @allow_stderr = true
   end
 
+  chain :with_or_without_stderr do
+    @ignore_stderr = true
+  end
+
   match do |result|
     return false if result.exit_code != 0
-    return false if !result.stderr.empty? && !@allow_stderr
+    return false if !@ignore_stderr && !result.stderr.empty? && !@allow_stderr
     return false if result.stderr.empty? && @allow_stderr
 
     true

--- a/lib/pennyworth/remote_command_runner.rb
+++ b/lib/pennyworth/remote_command_runner.rb
@@ -46,6 +46,7 @@ module Pennyworth
 
       Cheetah.run(
         "ssh",
+        "-q",
         "-o",
         "UserKnownHostsFile=/dev/null",
         "-o",

--- a/lib/pennyworth/remote_command_runner.rb
+++ b/lib/pennyworth/remote_command_runner.rb
@@ -56,8 +56,6 @@ module Pennyworth
         *args,
         options
       )
-    rescue Cheetah::ExecutionFailed => e
-      raise ExecutionFailed.new(e)
     end
 
     # Copy a local file to the remote system.

--- a/lib/pennyworth/runner.rb
+++ b/lib/pennyworth/runner.rb
@@ -21,7 +21,7 @@ module Pennyworth
     attr_reader :command_runner
 
     def cleanup_directory(dir)
-      command_runner.run("test -d #{dir} && rm -r #{dir}")
+      command_runner.run("test -d #{dir} && rm -r #{dir} || true")
     end
   end
 end

--- a/lib/pennyworth/spec.rb
+++ b/lib/pennyworth/spec.rb
@@ -38,6 +38,7 @@ require_relative "remote_command_runner"
 require_relative "settings"
 require_relative "local_runner"
 require_relative "local_command_runner"
+require_relative "matchers"
 
 module Pennyworth
   module SpecHelper

--- a/lib/pennyworth/version.rb
+++ b/lib/pennyworth/version.rb
@@ -16,7 +16,5 @@
 # you may find current contact information at www.suse.com
 
 module Pennyworth
-
-  VERSION = "0.1.0"
-
+  VERSION = "0.2.0"
 end

--- a/lib/pennyworth/vm.rb
+++ b/lib/pennyworth/vm.rb
@@ -37,7 +37,7 @@ module Pennyworth
       @runner.stop
     end
 
-    def run(*args)
+    def run_command(*args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
 
       opts.merge!(

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -19,20 +19,6 @@ require "pennyworth/spec"
 require "pennyworth/vm"
 
 describe "VM matchers" do
-  describe "have_exit_code" do
-    let(:result) { command_result("", "", 0) }
-
-    it "passes" do
-      expect(result).to have_exit_code(0)
-    end
-
-    it "fails" do
-      expect {
-        expect(result).to have_exit_code(1)
-      }.to raise_error(/to have exit code 1/)
-    end
-  end
-
   describe "succeed" do
     it "passes" do
       expect(command_result("", "", 0)).to succeed
@@ -42,6 +28,16 @@ describe "VM matchers" do
       expect {
         expect(command_result("", "", 1)).to succeed
       }.to raise_error(/Expected.*the command.*but it returned with exit code 1/m)
+    end
+
+    context "with .with_or_without_stderr" do
+      it "passes if there is stderr" do
+        expect(command_result("", "foo", 0)).to succeed.with_or_without_stderr
+      end
+
+      it "passes if there is no stderr" do
+        expect(command_result("", "", 0)).to succeed.with_or_without_stderr
+      end
     end
 
     context "with stderr output" do

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,0 +1,179 @@
+# Copyright (c) 2013-2014 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+require "pennyworth/spec"
+require "pennyworth/vm"
+
+describe "VM matchers" do
+  describe "have_exit_code" do
+    let(:result) { command_result("", "", 0) }
+
+    it "passes" do
+      expect(result).to have_exit_code(0)
+    end
+
+    it "fails" do
+      expect {
+        expect(result).to have_exit_code(1)
+      }.to raise_error(/to have exit code 1/)
+    end
+  end
+
+  describe "succeed" do
+    it "passes" do
+      expect(command_result("", "", 0)).to succeed
+    end
+
+    it "fails on exit code != 0" do
+      expect {
+        expect(command_result("", "", 1)).to succeed
+      }.to raise_error(/Expected.*the command.*but it returned with exit code 1/m)
+    end
+
+    context "with stderr output" do
+      let(:result) { command_result("", "foo", 0) }
+
+      it "fails" do
+        expect {
+          expect(result).to succeed
+        }.to raise_error(/Expected.*the command.*but it had stderr output/m)
+      end
+
+      it "passes if '.with_stderr' was used" do
+        expect(result).to succeed.with_stderr
+      end
+    end
+  end
+
+  describe "fail" do
+    it "passes" do
+      expect(command_result("", "", 1)).to fail
+    end
+
+    it "fails" do
+      expect {
+        expect(command_result("", "", 0)).to fail
+      }.to raise_error(/but it succeeded/)
+    end
+
+    context ".with_exit_code" do
+      it "passes on exit code" do
+        expect(command_result("", "", 3)).to fail.with_exit_code(3)
+      end
+
+      it "fails on exit code" do
+        expect {
+          expect(command_result("", "", 3)).to fail.with_exit_code(2)
+        }.to raise_error(/Expected.*the command.*but it exited with 3/m)
+      end
+    end
+  end
+
+  describe "have_stderr" do
+    let(:result) { command_result("", "foo", 1) }
+
+    context "with a Regexp" do
+      it "passes" do
+        expect(result).to have_stderr(/f.o/)
+      end
+
+      it "fails" do
+        expect {
+          expect(result).to have_stderr(/g.o/)
+        }.to raise_error(/to match \/g.o\//)
+      end
+    end
+
+    context "with a String" do
+      it "passes" do
+        expect(result).to have_stderr("foo")
+      end
+
+      it "fails" do
+        expect {
+          expect(result).to have_stderr("bar")
+        }.to raise_error(/to be 'bar'/)
+      end
+    end
+  end
+
+  describe "include_stderr" do
+    let(:result) { command_result("", "foo", 1) }
+
+    it "passes" do
+      expect(result).to include_stderr("fo")
+    end
+
+    it "fails" do
+      expect {
+        expect(result).to include_stderr("ba")
+      }.to raise_error(/to include 'ba'/)
+    end
+  end
+
+  describe "have_stdout" do
+    let(:result) { command_result("foo", "", 0) }
+
+    context "with a Regexp" do
+      it "passes" do
+        expect(result).to have_stdout(/f.o/)
+      end
+
+      it "fails" do
+        expect {
+          expect(result).to have_stdout(/g.o/)
+        }.to raise_error(/to match \/g.o\//)
+      end
+    end
+
+    context "with a String" do
+      it "passes" do
+        expect(result).to have_stdout("foo")
+      end
+
+      it "fails" do
+        expect {
+          expect(result).to have_stdout("bar")
+        }.to raise_error(/to be 'bar'/)
+      end
+    end
+  end
+
+  describe "include_stdout" do
+    let(:result) { command_result("foo", "", 0) }
+
+    it "passes" do
+      expect(result).to include_stdout("fo")
+    end
+
+    it "fails" do
+      expect {
+        expect(result).to include_stdout("ba")
+      }.to raise_error(/to include 'ba'/)
+    end
+  end
+
+  def command_result(stdout, stderr, exit_code)
+    res = Pennyworth::VM::CommandResult.new
+    res.cmd = "the command"
+    res.stdout = stdout
+    res.stderr = stderr
+    res.exit_code = exit_code
+
+    res
+  end
+end

--- a/spec/remote_command_runner_spec.rb
+++ b/spec/remote_command_runner_spec.rb
@@ -36,22 +36,12 @@ describe Pennyworth::RemoteCommandRunner do
     it "executes commands as given user" do
       expect(Cheetah).to receive(:run).
         with(
-        "ssh", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no",
-        "root@1.2.3.4", "LC_ALL=C", "su", "-l", "vagrant", "-c", "ls", "-l", "/etc/hosts",
-        stdout: :capture).
-        and_return(ssh_output)
+          "ssh", "-q", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no",
+          "root@1.2.3.4", "LC_ALL=C", "su", "-l", "vagrant", "-c", "ls", "-l", "/etc/hosts",
+          any_args
+        ).and_return(ssh_output)
 
-      output = command_runner.run("ls", "-l", "/etc/hosts", as: "vagrant", stdout: :capture)
-
-      expect(output).to eq (ssh_output)
-    end
-
-    it "raises ExecutionFailed in case of errors" do
-      expect(Cheetah).to receive(:run).and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
-
-      expect {
-        command_runner.run("foo")
-      }.to raise_error(Pennyworth::ExecutionFailed)
+      command_runner.run("ls", "-l", "/etc/hosts", as: "vagrant")
     end
   end
 

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -22,11 +22,11 @@ describe Pennyworth::VM do
   let(:runner) { double(command_runner: command_runner) }
   subject { Pennyworth::VM.new(runner) }
 
-  describe "#run_command" do
+  describe "#run" do
     it "lets the CommandRunner run the command" do
       expect(command_runner).to receive(:run)
 
-      subject.run_command("ls")
+      subject.run("ls")
     end
   end
 

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -22,11 +22,11 @@ describe Pennyworth::VM do
   let(:runner) { double(command_runner: command_runner) }
   subject { Pennyworth::VM.new(runner) }
 
-  describe "#run" do
+  describe "#run_command" do
     it "lets the CommandRunner run the command" do
       expect(command_runner).to receive(:run)
 
-      subject.run("ls")
+      subject.run_command("ls")
     end
   end
 


### PR DESCRIPTION
Please review the following changes:
  * 742e92a Update documentation
  * 8658b8e Bump version
  * e150c9e Change RSpec syntax
  * 5800a61 Do not raise exceptions when commands fail anymore
  * b6ebeb8 Suppress SSH warnings. They might trigger false failures
  * 4317d39 Fix ugly error message when a to-be-cleaned-up dir does not exist