### PR TITLE
Add an option to avoid stopping the VM after the tests

### DIFF
--- a/lib/pennyworth/spec.rb
+++ b/lib/pennyworth/spec.rb
@@ -44,7 +44,8 @@ module Pennyworth
   module SpecHelper
     def start_system(opts)
       opts = {
-        skip_ssh_setup: false
+        skip_ssh_setup: false,
+        stop: true
       }.merge(opts)
       username = opts[:username] || "root"
       if opts[:box]
@@ -65,9 +66,12 @@ module Pennyworth
 
       system = VM.new(runner)
 
-      # Make sure to stop the machine again when the example group is done
-      self.class.after(:all) do
-        system.stop
+      # Make sure to stop the machine again when the example group is
+      # done unless 'stop' option is set to false.
+      if opts[:stop]
+        self.class.after(:all) do
+          system.stop
+        end
       end
 
       measure("Boot machine '#{opts[:box] || opts[:image] || opts[:host]}'") do

--- a/spec/spec_spec.rb
+++ b/spec/spec_spec.rb
@@ -95,5 +95,17 @@ describe Pennyworth::SpecHelper do
 
       start_system(opts.merge(local: true))
     end
+
+    context "when 'stop' option is set to false" do
+      it "does not stop the machine after the tests" do
+        runner = double
+        expect(runner).to receive(:start)
+        expect(Pennyworth::VagrantRunner).to receive(:new).and_return(runner)
+        expect(Pennyworth::SshKeysImporter).to receive(:import)
+
+        expect(self.class).to_not receive(:after)
+        start_system(box: system_one, stop: false)
+      end
+    end
   end
 end


### PR DESCRIPTION
I'd like to execute some code before the machine is stopped so I'd like `#start_system` to not stop the machine automatically. So I think that adding an option `stop` to avoid this will be useful.