### PR TITLE
Allow vagrant destroy to fail

### DIFF
--- a/lib/pennyworth/vagrant_command.rb
+++ b/lib/pennyworth/vagrant_command.rb
@@ -111,6 +111,7 @@ module Pennyworth
 
     def destroy
       @vagrant.run "destroy"
+    rescue Cheetah::ExecutionFailed
     end
 
     def add_box box, box_path


### PR DESCRIPTION
`vagrant destroy` is run every time an image is started. If the image
wasn't started manually before it might fail because there is nothing to
destroy.

This case shouldn't prevent Pennyworth/rspec from working since there
wasn't anything to destroy in the first place.