### PR TITLE
[Review] Request from 'aduffeck' @ 'SUSE/pennyworth/review_150806_fix_ip_detection'

### DIFF
--- a/lib/pennyworth/commands/boot_command.rb
+++ b/lib/pennyworth/commands/boot_command.rb
@@ -18,7 +18,7 @@
 module Pennyworth
   class BootCommand < Command
     def execute(image)
-      runner = ImageRunner.new(image)
+      runner = ImageRunner.new(image, "root")
       log "Starting image #{runner.name}"
 
       ip = VM.new(runner).start

--- a/lib/pennyworth/image_runner.rb
+++ b/lib/pennyworth/image_runner.rb
@@ -88,6 +88,4 @@ module Pennyworth
       ip_address
     end
   end
-
-
 end

--- a/lib/pennyworth/image_runner.rb
+++ b/lib/pennyworth/image_runner.rb
@@ -70,11 +70,15 @@ module Pennyworth
       ip_address = nil
 
       # Loop until the VM has got an IP address we can return
-      lease_file = "/var/lib/libvirt/dnsmasq/default.leases"
       300.times do
-        match = File.readlines(lease_file).grep(/#{mac}/).first
-        if match
-          ip_address = match.split[2]
+        ip_address = Cheetah.run(
+          ["arp", "-n"],
+          ["grep", mac],
+          ["cut", "-d", " ", "-f", "1"],
+          stdout: :capture
+        ).chomp
+
+        if ip_address.length > 0
           break
         end
 

--- a/spec/image_runner_spec.rb
+++ b/spec/image_runner_spec.rb
@@ -29,9 +29,6 @@ describe Pennyworth::ImageRunner do
       </domain>
     EOF
   }
-  let(:lease_file) {
-    ["1390553648 52:54:01:60:3c:95 192.168.122.186 vagrant-opensuse 52:54:01:60:3c:95"]
-  }
   let(:runner) { Pennyworth::ImageRunner.new("/path/to/image", "root") }
 
   describe "runner" do
@@ -52,9 +49,13 @@ describe Pennyworth::ImageRunner do
       expect(libvirt).to receive(:lookup_domain_by_name) { system }
 
       expect(system).to receive(:xml_desc) { libvirt_xml }
-      expect(File).to receive(:readlines) { lease_file }
 
       allow(runner).to receive(:cleanup)
+      expect(Cheetah).to receive(:run) do |*cmd|
+        expect(cmd.first[0]).to eq("arp")
+
+        "192.168.122.186"
+      end
 
       expect(runner.start).to eq("192.168.122.186")
     end


### PR DESCRIPTION
Please review the following changes:
  * 039d013 Fix superfluous whitespace
  * 2d0bbea Use ARP to get the IP address of the booted image
  * 2f706c1 Adapt "boot" command to changed ImageRunner constructor signature